### PR TITLE
QtPropertyBrowser: Fix an issue when setting "flagNames"

### DIFF
--- a/qtpropertybrowser/src/qtvariantproperty.cpp
+++ b/qtpropertybrowser/src/qtvariantproperty.cpp
@@ -429,10 +429,10 @@ QtVariantProperty *QtVariantPropertyManagerPrivate::createSubProperty(QtVariantP
     varChild->setStatusTip(internal->statusTip());
     varChild->setWhatsThis(internal->whatsThis());
 
-    parent->insertSubProperty(varChild, after);
-
     m_internalToProperty[internal] = varChild;
     propertyToWrappedProperty()->insert(varChild, internal);
+
+    parent->insertSubProperty(varChild, after);
     return varChild;
 }
 


### PR DESCRIPTION
Setting the "flagNames" attribute causes the QtFlagPropertyManager to
re-create its child properties. This causes the QtVariantPropertyManager
to re-create its wrapping QtVariantProperty instances.

When this happens with a property that is already added to a property
browser, the value icon and text were requested before the
QtVariantPropertyManager had set up the mapping between the wrapping
QtVariantProperty instance and the internal property. This caused the
returned icon and text for the child flag properties to be empty.

Change-Id: If2166136b4ae3931c229c215f90f8582da81d2c3
Reviewed-by: Jarek Kobus <jaroslaw.kobus@qt.io>